### PR TITLE
Bump version of terminal-notifier dependency

### DIFF
--- a/cucumber-nc.gemspec
+++ b/cucumber-nc.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |gem|
   gem.summary       = "Cucumber formatter for Mountain Lion's Notification Center"
   gem.homepage      = 'https://github.com/MrJoy/cucumber-nc'
 
-  gem.add_dependency 'terminal-notifier', '~> 1.4.2'
+  gem.add_dependency 'terminal-notifier', '~> 1.6.2'
   gem.add_dependency 'cucumber', '~> 1.2'
 
   gem.files         = `git ls-files`.split($\)


### PR DESCRIPTION
terminal-notifier 1.4.2 has an OS X version check that fails for OS X 10.10 (see https://github.com/alloy/terminal-notifier/issues/92). The version check is fixed in terminal-notifier 1.6.2.
